### PR TITLE
Add `convertGitHubMention` option to release task

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ jobs:
 
 - `task` (required): Must be `release`.
 - `token` (required): GitHub token.
+- `convertGitHubMention` (optional: `true` by default): Set whether to convert Markdown links to GitHub profile like `[@marp-team](https://github.com/marp-team/)` into a plain GitHub mention.
+
+<details>
+<summary>Details about <code>convertGitHubMention</code></summary>
+
+For giving honor, `CHANGELOG.md` may mention to outside contributors who made a good improvement (e.g. Bug fix, critical update of docs, and so on. Minor fix such as typo may not mention to the contributor).
+
+We are using a traditional Markdown link into GitHub profile page to keep accessible when reading `CHANGELOG.md` directly, but using `@mention` syntax for GitHub releases is better because of [the avatar list for to highlight and celebrate our collaborators.](https://github.blog/changelog/2021-09-14-releases-now-have-an-avatar-list/)
+
+</details>
 
 ### `upload`: Upload assets to existing GitHub Release
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Token string for GitHub
     required: true
 
+  # "release" task
+  convertGitHubMention:
+    description: Set whether to convert Markdown links to GitHub profile into a plain GitHub mention
+
   # "upload" task
   files:
     description: Comma-separated string for upload files or directories

--- a/src/tasks/upload.ts
+++ b/src/tasks/upload.ts
@@ -27,7 +27,7 @@ const resolveFiles = async (files: string[]) => {
             .map((d) => path.resolve(f, d.name))
         )
       }
-    } catch (e) {
+    } catch (e: any) {
       if (e.code !== 'ENOENT') throw e
     }
   }


### PR DESCRIPTION
For giving honor, `CHANGELOG.md` may mention to outside contributors who made a good improvement (e.g. Bug fix, critical update of docs, and so on. Minor fix such as typo may not mention to the contributor).

We are using a traditional Markdown link into GitHub profile page to keep accessible when reading `CHANGELOG.md` directly, but using `@mention` syntax for GitHub releases is better because of [the avatar list for to highlight and celebrate our collaborators.](https://github.blog/changelog/2021-09-14-releases-now-have-an-avatar-list/)